### PR TITLE
Bugfix: changed cache suffix and style fix zf toolbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "zendframework/zend-developer-tools":   "dev-master",
         "squizlabs/php_codesniffer":            "~1",
         "zendframework/zend-view":              "~2.3",
-        "zendframework/zend-cache":             "~2.3"
+        "zendframework/zend-cache":             "~2.3",
+        "phpunit/phpunit": "~4.2.0"
     },
     "autoload":     {
         "psr-0": {

--- a/src/VersionEyeModule/Collector/DependencyStatusCollector.php
+++ b/src/VersionEyeModule/Collector/DependencyStatusCollector.php
@@ -33,8 +33,8 @@ use ZendDeveloperTools\Collector\CollectorInterface;
 class DependencyStatusCollector implements CollectorInterface, \Serializable
 {
     const DEFAULT_PRIORITY = 100;
-    const CACHE_KEY_SUFFIX = '.project';
-    const CACHE_DATA_SUFFIX = '.data';
+    const CACHE_KEY_SUFFIX = '-project';
+    const CACHE_DATA_SUFFIX = '-data';
 
     /**
      * @var Client
@@ -108,11 +108,20 @@ class DependencyStatusCollector implements CollectorInterface, \Serializable
     }
 
     /**
+     * @param bool $outdatedFirst
      * @return array|null
      */
-    public function getCollectedDependencyStatuses()
+    public function getCollectedDependencyStatuses($outdatedFirst = false)
     {
-        return $this->collected;
+        $statuses = $this->collected;
+        if ($outdatedFirst && isset($statuses['dependencies'])) {
+            $dependencies = $statuses['dependencies'];
+            usort($dependencies, function ($dependency) {
+                return !$dependency['outdated'];
+            });
+            $statuses['dependencies'] = $dependencies;
+        }
+        return $statuses;
     }
 
     /**

--- a/src/VersionEyeModule/Collector/DependencyStatusCollector.php
+++ b/src/VersionEyeModule/Collector/DependencyStatusCollector.php
@@ -108,13 +108,12 @@ class DependencyStatusCollector implements CollectorInterface, \Serializable
     }
 
     /**
-     * @param bool $outdatedFirst
      * @return array|null
      */
-    public function getCollectedDependencyStatuses($outdatedFirst = false)
+    public function getCollectedDependencyStatuses()
     {
         $statuses = $this->collected;
-        if ($outdatedFirst && isset($statuses['dependencies'])) {
+        if (isset($statuses['dependencies'])) {
             $dependencies = $statuses['dependencies'];
             usort($dependencies, function ($dependency) {
                 return !$dependency['outdated'];

--- a/tests/VersionEyeModuleTest/Collector/DependencyStatusCollectorTest.php
+++ b/tests/VersionEyeModuleTest/Collector/DependencyStatusCollectorTest.php
@@ -59,6 +59,37 @@ class DependencyStatusCollectorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testCollectWithOutdatedFirst()
+    {
+        $this->http->expects($this->never())->method('request');
+
+        $data = array(
+            'dependencies' => array(
+                array('name' => 'not-outdated' , 'outdated' => false),
+                array('name' => 'outdated' , 'outdated' => true)
+            )
+        );
+
+        $this
+            ->cache
+            ->expects($this->atLeastOnce())
+            ->method('getItem')
+            ->will($this->returnValueMap(array(
+                array('test_cache_key'.DependencyStatusCollector::CACHE_KEY_SUFFIX,null,null, 'foo'),
+                array('test_cache_key'.DependencyStatusCollector::CACHE_DATA_SUFFIX,null,null, $data)
+            )));
+
+        $this->collector->collect($this->getMock('Zend\\Mvc\\MvcEvent'));
+
+        $this->assertSame(array(
+            'dependencies' => array(
+                array('name' => 'outdated' , 'outdated' => true),
+                array('name' => 'not-outdated' , 'outdated' => false)
+            )),
+            $this->collector->getCollectedDependencyStatuses(true)
+        );
+    }
+
     public function testCollectWithValidCache()
     {
         $this->http->expects($this->never())->method('request');

--- a/tests/VersionEyeModuleTest/Collector/DependencyStatusCollectorTest.php
+++ b/tests/VersionEyeModuleTest/Collector/DependencyStatusCollectorTest.php
@@ -59,7 +59,7 @@ class DependencyStatusCollectorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCollectWithOutdatedFirst()
+    public function testCollectOutdatedOrder()
     {
         $this->http->expects($this->never())->method('request');
 
@@ -86,7 +86,7 @@ class DependencyStatusCollectorTest extends \PHPUnit_Framework_TestCase
                 array('name' => 'outdated' , 'outdated' => true),
                 array('name' => 'not-outdated' , 'outdated' => false)
             )),
-            $this->collector->getCollectedDependencyStatuses(true)
+            $this->collector->getCollectedDependencyStatuses()
         );
     }
 

--- a/view/zend-developer-tools/toolbar/version-eye-status.phtml
+++ b/view/zend-developer-tools/toolbar/version-eye-status.phtml
@@ -1,7 +1,7 @@
 <?php
 /* @var $collector \VersionEyeModule\Collector\DependencyStatusCollector */
 
-$statuses = $collector->getCollectedDependencyStatuses();
+$statuses = $collector->getCollectedDependencyStatuses(true);
 if ( ! $statuses) {
 ?>
 <div class="zdt-toolbar-entry">
@@ -28,17 +28,17 @@ if ( ! $statuses) {
 return;
 }
 ?>
-<div class="zdt-toolbar-entry">
+<div class="zdt-toolbar-entry version-eye-toolbar-entry">
     <div class="zdt-toolbar-preview">
         <!-- @todo versioneye icon? -->
         <img src="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAAXNSR0IArs4c6QAAA0JJREFUOMudVEFoI1UY/t4kk2yUylZlFNuaDduw2A2IiCD0WgQPqVUsewgt6kXQXEpPnoqnii3tJeAacVdahNLSiyClttCSgdimCZWCuOykk5mNEtYsNGYmTCaZ934vWai4ibXf6f3vfXx8//++9xi6QNO0d0Oh0LoQouW67s1oNGrgApDOF4ZhfGea5hQAnJ2dRTjnPtd1n2o0Gi8BgGmaXxiG8WUvQfZ4USqV7vp8vg+EEGCMnTLGrneOCAAjIgPANQAQQnwSiUS+6uqwv79fSqVST3POCQCI6HogEIBt2+S6LvP5fCCia0QEy7L48vLyMxdp/4qqqm3DMEjXdZFMJu8DSEuStLqwsPDANE0yTZN2d3dNAL6eSsVi8X1N05K6rlO5XKbZ2dmfAQyco9xcXFy8XyqVSNd1R9O0j4rF4uSTtPydmawRESMiVKtVpFKpWwD+OMf7tVKpfFqv138KhUJBAN8QEQHYeKKgZVlMlmUWCAQgyzKazebvjLF/EKempiqSJEEIwZrNJjjn6OpwYmLie0VRXlhbW3srGAwin89/C+DD80TO+bIsy3Acx0skEj82Gg2rZ2wAYHt7mw8ODkpEBCL6mohuA5AZY58DeFuSJOi6Xo7H4y//Zw5PTk6WOOczjDF0WgOAdudGpcd7RNSWZfnjWCx2t9dLkVRVDQshUKvV2rlc7qFt24Jz7uecs1qtxo+Ojv50HIc3m03f1tbWiwBQKBQCvdITmZyc/CUej98G8NrMzMydg4MDoaoqjY2NfQbg9enp6d3x8fEdAFcBIJfL3Ts+Ppa6zhDAFQAyAGtlZWU6HA7fcV0X1Wr1lUQioQF4fmNj4+rAwEBGkqQMY+wWEW0KId4kondGR0cLrJvdoaGhG4yx9wB4RJQul8t/AUA0Gn1uaWnpkaIoOD09dSORSLBer2Nzc3MknU7/hv+LTCZD2WyW5ufnKwCSc3NzejabpUwm4/3r+7oIdnZ2XNu2xfDwsENEP8RisbrjOLS/v29dStC27Tc8z2OKokT29vbuKYryqud58Pv9E5cSbLVarXw+/2h1dTXX19cXWl9fLxweHj6s1WptXBJ+ADcAPDsyMmIwxsKdOggAfwOpZLGNo7pH7AAAAABJRU5ErkJggg==" alt="VersionEye dependencies statuses">
-        <span class="version-eye-toolbar-info">
+        <span class="zdt-toolbar-info">
             <?php echo count($statuses['dependencies']); ?> dependencies
         </span>
     </div>
-    <div class="zdt-toolbar-detail">
+    <div class="zdt-toolbar-detail version-eye-toolbar-detail">
         <span class="zdt-toolbar-info version-eye-toolbar-info-heading">
-            <a href="https://github.com/Ocramius/VersionEyeModule" target="_blank">VersionEyeModule</a>
+            <a href="https://github.com/Ocramius/VersionEyeModule" target="_blank"><strong>VersionEyeModule</strong></a>
         </span>
         <span class="zdt-toolbar-info version-eye-toolbar-info">
             <?php foreach ($statuses['dependencies'] as $dependency): ?>
@@ -73,9 +73,8 @@ return;
 {
     font-size: 11px;
     max-width: 600px;
-    witdh: 600px;
-    max-height: 300px;
-    overflow-y: scroll;
+    max-height: 400px !important;
+    overflow-y: auto !important;
     overflow-x: hidden;
 }
 

--- a/view/zend-developer-tools/toolbar/version-eye-status.phtml
+++ b/view/zend-developer-tools/toolbar/version-eye-status.phtml
@@ -1,7 +1,7 @@
 <?php
 /* @var $collector \VersionEyeModule\Collector\DependencyStatusCollector */
 
-$statuses = $collector->getCollectedDependencyStatuses(true);
+$statuses = $collector->getCollectedDependencyStatuses();
 if ( ! $statuses) {
 ?>
 <div class="zdt-toolbar-entry">


### PR DESCRIPTION
### Changes ###

- Dot (.) in cache suffix is not enabled in default filesystem cache configuration. Changed with dash (-).
- ZF toolbar dependencies list style fixes.
- Dependencies list view: outdated dependencies first.